### PR TITLE
#33: Add customizable key/label names and allow decorator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class SomeApp(AppConfig):
         register.register(some_object, db_key='some_label')
 ```
 
-It does not have to be in the `ready` method, values can be added to the register anywhere, however you should be very careful about where you allow adding values and when. If the value is not available somewhere in the code, it will return the `unknow_item_class` instead of the expected object.
+It does not have to be in the `ready` method, values can be added to the register anywhere, however you should be very careful about where you allow adding values and when. If the value is not available somewhere in the code, it will return the `unknown_item_class` instead of the expected object.
 
 ## Considerations when removing objects
 

--- a/django_register/base.py
+++ b/django_register/base.py
@@ -27,7 +27,10 @@ class Register:
         self._class_to_key = {}
         self.unknown_item_class = unknown_item_class or UnknownRegisterItem
 
-    def register(self, klass, db_key=None):
+    def register(self, klass=None, db_key=None):
+        if klass is None:
+            return lambda k: self.register(k, db_key=db_key)
+
         if db_key is None:
             try:
                 db_key = getattr(klass, settings.KEY_NAME)

--- a/django_register/rest_framework.py
+++ b/django_register/rest_framework.py
@@ -9,6 +9,7 @@ from rest_framework import serializers
 
 # django_register
 from django_register.base import Register
+from .settings import settings
 
 if TYPE_CHECKING:
     # Rest Framework
@@ -72,11 +73,11 @@ class RegisterField(serializers.CharField):
             try:
                 out[key] = getattr(value, key)
             except AttributeError:
-                # If label or verbose_name are not on the object, the default was used.
+                # If key or label are not on the object, the default was used.
                 # We can get the default from the register.
-                if key == "label":
+                if key == settings.KEY_NAME:
                     out[key] = self.register.get_key(value)
-                elif key == "verbose_name":
+                elif key == settings.LABEL_NAME:
                     out[key] = self.register.get_key(value).replace("_", " ").title()
                 else:
                     errors.append(key)

--- a/django_register/settings.py
+++ b/django_register/settings.py
@@ -1,0 +1,41 @@
+from django.conf import settings as django_settings
+from django.core.signals import setting_changed
+
+DEFAULTS = {
+    "KEY_NAME": "key",
+    "LABEL_NAME": "label",
+}
+
+
+class Settings:
+    def __getattr__(self, item):
+        try:
+            return getattr(django_settings, "REGISTER_FIELD_" + item)
+        except AttributeError:
+            if item in DEFAULTS:
+                return DEFAULTS[item]
+            raise AttributeError("Invalid REGISTER_FIELD setting: '%s'" % item)
+
+    def change_setting(self, setting, value, enter, **kwargs):
+        if not setting.startswith("REGISTER_FIELD_"):
+            return
+        setting = setting[15:]  # strip 'REGISTER_FIELD_'
+
+        # ensure a valid app setting is being overridden
+        if setting not in DEFAULTS:
+            return
+
+        # if entering, set the value; if exiting, restore or delete
+        if enter:
+            setattr(self, setting, value)
+        else:
+            # Only try to delete if the attribute exists as an instance attribute
+            if hasattr(self, setting):
+                delattr(self, setting)
+            # If value is not None, it means we're restoring to a previous override
+            if value is not None:
+                setattr(self, setting, value)
+
+
+settings = Settings()
+setting_changed.connect(settings.change_setting)

--- a/migration_v1_to_v2.md
+++ b/migration_v1_to_v2.md
@@ -1,0 +1,16 @@
+# Migrating from V1 to V2
+
+There was a fairly major change made in V2 that will break V1 implementations.
+
+`label` has been renamed to `key` and `verbose_name` has been renamed to `label`.
+This is to be more inline with the naming conventions in django as a whole,
+especially with Choices taking `label` as being the name to be displayed.
+
+You can either make the change in your codebase, or use the newly implemented `REGISTER_FIELD_KEY_NAME` and `REGISTER_FIELD_LABEL_NAME` to change this behaviour.
+
+For exmaple, if you wanted to keep the old behaviour, you could add these lines to your `settings.py`:
+
+``` python
+REGISTER_FIELD_KEY_NAME="label"
+REGISTER_FIELD_LABEL_NAME="verbose_name"
+```

--- a/migration_v1_to_v2.md
+++ b/migration_v1_to_v2.md
@@ -8,7 +8,7 @@ especially with Choices taking `label` as being the name to be displayed.
 
 You can either make the change in your codebase, or use the newly implemented `REGISTER_FIELD_KEY_NAME` and `REGISTER_FIELD_LABEL_NAME` to change this behaviour.
 
-For exmaple, if you wanted to keep the old behaviour, you could add these lines to your `settings.py`:
+For example, if you wanted to keep the old behaviour, you could add these lines to your `settings.py`:
 
 ``` python
 REGISTER_FIELD_KEY_NAME="label"

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("label", models.CharField(max_length=50)),
+                ("name", models.CharField(max_length=50)),
                 (
                     "country",
                     django_register.base.RegisterField(
@@ -73,7 +73,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("label", models.CharField(max_length=50)),
+                ("name", models.CharField(max_length=50)),
                 (
                     "city",
                     models.ForeignKey(

--- a/tests/models.py
+++ b/tests/models.py
@@ -23,12 +23,12 @@ class CountryChoices(RegisterChoices):
 
 @dataclass(unsafe_hash=True)
 class ContinentInfo:
-    label: str
+    key: str
 
 
 @dataclass(unsafe_hash=True)
 class FoodInfo:
-    verbose_name: str
+    label: str
 
 
 food_register = Register()
@@ -37,19 +37,19 @@ food_register.register(FoodInfo("Pizza"), db_key="pizza")
 
 @dataclass(unsafe_hash=True)
 class CarCompanies:
-    verbose_name: str
+    label: str
 
 
 cars_register = Register()
 
 
 class ContinentChoices(RegisterChoices):
-    AMERICA = ContinentInfo(label="America")
-    EUROPE = ContinentInfo(label="Europe")
+    AMERICA = ContinentInfo(key="America")
+    EUROPE = ContinentInfo(key="Europe")
 
 
 class City(models.Model):
-    label = models.CharField(max_length=50)
+    name = models.CharField(max_length=50)
     country = RegisterField(
         choices=CountryChoices, default=CountryChoices.UNITED_STATES
     )
@@ -61,5 +61,5 @@ class City(models.Model):
 
 
 class Neighborhood(models.Model):
-    label = models.CharField(max_length=50)
+    name = models.CharField(max_length=50)
     city = models.ForeignKey(City, on_delete=models.CASCADE)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -14,7 +14,7 @@ class CityAdmin(admin.ModelAdmin):
 class AdminTestCase(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.city = City.objects.create(label="Ottawa")
+        cls.city = City.objects.create(name="Ottawa")
 
     def setUp(self):
         self.admin = CityAdmin(City, admin.site)
@@ -65,7 +65,7 @@ class AdminTestCase(TestCase):
             register.choices, [("America", "America"), ("Europe", "Europe")]
         )
 
-        register.register(ContinentInfo(label="Asia"))
+        register.register(ContinentInfo(key="Asia"))
 
         field = self.admin.opts._forward_fields_map["continent"]
 

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -39,7 +39,7 @@ class ChoicesTestCase(TestCase):
 
     def test_register_unknown_option(self):
         class UnknownOption:
-            label: str
+            key: str
             description: str = ""
 
         class CountryChoices(RegisterChoices):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -18,8 +18,8 @@ from tests.models import (
 class RegisterFieldTestCase(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.paris = City.objects.create(label="Paris", country=CountryChoices.FRANCE)
-        cls.berlin = City.objects.create(label="Berlin", country=CountryChoices.GERMANY)
+        cls.paris = City.objects.create(name="Paris", country=CountryChoices.FRANCE)
+        cls.berlin = City.objects.create(name="Berlin", country=CountryChoices.GERMANY)
 
     def test_can_retrieve_obj(self):
         self.assertEqual(self.paris.country, CountryChoices.FRANCE)
@@ -53,7 +53,7 @@ class RegisterFieldTestCase(TestCase):
         )
 
     def test_default_value(self):
-        city = City.objects.create(label="Ottawa")
+        city = City.objects.create(name="Ottawa")
         self.assertEqual(city.country, CountryChoices.UNITED_STATES)
         self.assertEqual(city._meta.get_field("country").default, "united_states")
 
@@ -61,7 +61,7 @@ class RegisterFieldTestCase(TestCase):
         City._meta.get_field("country").default = CountryInfo(12, capital="Max Capital")
 
         with self.assertRaises(ValidationError), self.assertWarns(UserWarning):
-            City.objects.create(label="Ottawa")
+            City.objects.create(name="Ottawa")
 
     def test_fails_if_fetching_before_registering(self):
         with self.assertRaises(ValueError):
@@ -93,7 +93,7 @@ class RegisterFieldTestCase(TestCase):
         cars_register._key_to_class.pop("hyundai")
 
     def test_annotations(self):
-        Neighborhood.objects.create(label="Montparnasse", city=self.paris)
+        Neighborhood.objects.create(name="Montparnasse", city=self.paris)
 
         neighborhood = Neighborhood.objects.annotate(
             country=models.F("city__country")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -61,3 +61,31 @@ class RegisterTestCase(TestCase):
         with self.assertWarns(UserWarning):
             obj = self.register.get_class("unknown")
         self.assertIsInstance(obj, OtherUnknownItem)
+
+
+class RegisterWithDecoratorTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.register = Register()
+
+    def test_register_with_decorator(self):
+        @self.register.register
+        class ItemA:
+            key = "item_a"
+
+        @self.register.register(db_key="item_b")
+        class ItemB:
+            pass
+
+        @self.register.register()
+        class ItemC:
+            key = "item_c"
+
+        self.assertEqual(self.register.get_key(ItemA), "item_a")
+        self.assertEqual(self.register.get_class("item_a"), ItemA)
+
+        self.assertEqual(self.register.get_key(ItemB), "item_b")
+        self.assertEqual(self.register.get_class("item_b"), ItemB)
+
+        self.assertEqual(self.register.get_key(ItemC), "item_c")
+        self.assertEqual(self.register.get_class("item_c"), ItemC)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -17,7 +17,7 @@ class RegisterTestCase(TestCase):
         with self.assertRaises(ValueError):
             self.register.register(country_info)
 
-        country_info.label = "max_country"
+        country_info.key = "max_country"
         self.register.register(country_info)
 
         self.assertEqual(self.register.get_class("max_country"), country_info)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -14,27 +14,27 @@ class CitySerialier(serializers.ModelSerializer):
 
     class Meta:
         model = City
-        fields = ("label", "country")
+        fields = ("name", "country")
 
 
 class RegisterSerializerTestCase(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.paris = City.objects.create(label="Paris", country=CountryChoices.FRANCE)
+        cls.paris = City.objects.create(name="Paris", country=CountryChoices.FRANCE)
 
     def test_serialization(self):
         serializer = CitySerialier(self.paris)
-        self.assertEqual(serializer.data, {"label": "Paris", "country": "france"})
+        self.assertEqual(serializer.data, {"name": "Paris", "country": "france"})
 
     def test_serializer_wrong_value(self):
-        serializer = CitySerialier(data={"label": "Paris", "country": "francis"})
+        serializer = CitySerialier(data={"name": "Paris", "country": "francis"})
         with self.assertWarns(UserWarning):
             self.assertFalse(serializer.is_valid())
         self.assertIn("country", serializer.errors)
 
     def test_save(self):
         serializer = CitySerialier(
-            data={"label": "Paris", "country": CountryChoices.FRANCE}
+            data={"name": "Paris", "country": CountryChoices.FRANCE}
         )
 
         self.assertTrue(serializer.is_valid())
@@ -44,12 +44,12 @@ class RegisterSerializerTestCase(TestCase):
 
     def test_wrong_field_type(self):
         class CitySerialier(serializers.ModelSerializer):
-            label = RegisterField()
+            name = RegisterField()
             country = RegisterField()
 
             class Meta:
                 model = City
-                fields = ("label", "country")
+                fields = ("name", "country")
 
         serializer = CitySerialier(self.paris)
 
@@ -57,21 +57,21 @@ class RegisterSerializerTestCase(TestCase):
             serializer.data
 
     def test_keys(self):
-        class CitySerialier(serializers.ModelSerializer):
-            country = RegisterField(keys=["label", "verbose_name", "capital"])
+        class CitySerializer(serializers.ModelSerializer):
+            country = RegisterField(keys=["key", "label", "capital"])
 
             class Meta:
                 model = City
-                fields = ("label", "country")
+                fields = ("name", "country")
 
-        serializer = CitySerialier(self.paris)
+        serializer = CitySerializer(self.paris)
         self.assertEqual(
             serializer.data,
             {
-                "label": "Paris",
+                "name": "Paris",
                 "country": {
-                    "label": "france",
-                    "verbose_name": "France",
+                    "key": "france",
+                    "label": "France",
                     "capital": "Paris",
                 },
             },

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,287 @@
+# Standard libraries
+from dataclasses import dataclass
+
+# Django
+from django.test import TestCase, override_settings
+from django.db import models
+
+# django_register
+from django_register import (
+    Register,
+    RegisterChoices,
+    RegisterField,
+)
+from django_register.base import UnknownRegisterItem
+from django_register.rest_framework import RegisterField as DRFRegisterField
+from django_register.settings import settings
+
+
+class SettingsTestCase(TestCase):
+    def test_default_settings(self):
+        self.assertEqual(settings.KEY_NAME, "key")
+        self.assertEqual(settings.LABEL_NAME, "label")
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_in_register(self):
+        @dataclass(unsafe_hash=True)
+        class CustomItem:
+            name: str
+            pretty_name: str
+
+        custom_register = Register()
+
+        item = CustomItem(name="test_key", pretty_name="Test Label")
+        custom_register.register(item)
+
+        self.assertEqual(custom_register.from_class(item), "test_key")
+        self.assertEqual(custom_register.from_key("test_key"), item)
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_with_unknown_item(self):
+        self.assertEqual(settings.KEY_NAME, "name")
+
+        unknown_item = UnknownRegisterItem()
+
+        self.assertTrue(hasattr(unknown_item, "name"))
+        self.assertIsNone(getattr(unknown_item, "name"))
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_in_register_choices(self):
+        @dataclass(unsafe_hash=True)
+        class CustomCountry:
+            name: str
+            pretty_name: str
+            population: int
+
+        class CustomCountryChoices(RegisterChoices):
+            FRANCE = CustomCountry(
+                name="fr", pretty_name="France", population=65_000_000
+            )
+            GERMANY = CustomCountry(
+                name="de", pretty_name="Germany", population=83_000_000
+            )
+
+        choices = CustomCountryChoices.choices
+        choice_dict = dict(choices)
+
+        self.assertEqual(choice_dict["fr"], "France")
+        self.assertEqual(choice_dict["de"], "Germany")
+
+        self.assertEqual(
+            CustomCountryChoices.register.from_class(CustomCountryChoices.FRANCE), "fr"
+        )
+        self.assertEqual(
+            CustomCountryChoices.register.from_key("fr"), CustomCountryChoices.FRANCE
+        )
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_register_choices_without_attributes(self):
+        @dataclass(unsafe_hash=True)
+        class SimpleCountry:
+            population: int
+
+        class SimpleCountryChoices(RegisterChoices):
+            FRANCE = SimpleCountry(population=65_000_000)
+            GERMANY = SimpleCountry(population=83_000_000)
+
+        choices = SimpleCountryChoices.choices
+        choice_dict = dict(choices)
+
+        self.assertEqual(choice_dict["france"], "France")
+        self.assertEqual(choice_dict["germany"], "Germany")
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_in_register_field(self):
+        @dataclass(unsafe_hash=True)
+        class CustomItem:
+            name: str
+            pretty_name: str
+
+        class CustomChoices(RegisterChoices):
+            ITEM1 = CustomItem(name="item1", pretty_name="Item One")
+            ITEM2 = CustomItem(name="item2", pretty_name="Item Two")
+
+        class TestModel(models.Model):
+            choice_field = RegisterField(choices=CustomChoices)
+
+            class Meta:
+                app_label = "tests"
+
+        choices = TestModel._meta.get_field("choice_field").choices
+        choice_dict = dict(choices)
+
+        self.assertEqual(choice_dict["item1"], "Item One")
+        self.assertEqual(choice_dict["item2"], "Item Two")
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_in_drf_serializer_field(self):
+        @dataclass(unsafe_hash=True)
+        class CustomItem:
+            name: str
+            pretty_name: str
+            extra_field: str
+
+        custom_register = Register()
+        item = CustomItem(
+            name="test_key", pretty_name="Test Label", extra_field="Extra"
+        )
+        custom_register.register(item)
+
+        field = DRFRegisterField(
+            register=custom_register, keys=["name", "pretty_name", "extra_field"]
+        )
+
+        representation = field.to_representation(item)
+        expected = {
+            "name": "test_key",
+            "pretty_name": "Test Label",
+            "extra_field": "Extra",
+        }
+        self.assertEqual(representation, expected)
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_custom_key_and_label_names_drf_field_defaults(self):
+        @dataclass(unsafe_hash=True)
+        class ItemWithoutCustomAttrs:
+            population: int
+
+        custom_register = Register()
+        item = ItemWithoutCustomAttrs(population=1000)
+        custom_register.register(item, db_key="test_item")
+
+        field = DRFRegisterField(register=custom_register, keys=["name", "pretty_name"])
+
+        representation = field.to_representation(item)
+        expected = {
+            "name": "test_item",
+            "pretty_name": "Test Item",
+        }
+        self.assertEqual(representation, expected)
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_register_error_messages_use_custom_key_name(self):
+        @dataclass(unsafe_hash=True)
+        class ItemWithoutKey:
+            population: int
+
+        register = Register()
+
+        with self.assertRaises(ValueError) as context:
+            register.register(ItemWithoutKey(population=1000))
+
+        error_message = str(context.exception)
+        self.assertIn("name", error_message)
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_settings_change_at_runtime(self):
+        from django_register.settings import settings as register_settings
+
+        self.assertEqual(register_settings.KEY_NAME, "name")
+        self.assertEqual(register_settings.LABEL_NAME, "pretty_name")
+
+        @override_settings(REGISTER_FIELD_KEY_NAME="identifier")
+        def inner_test():
+            self.assertEqual(register_settings.KEY_NAME, "identifier")
+            self.assertEqual(
+                register_settings.LABEL_NAME, "pretty_name"
+            )  # Should remain unchanged
+
+        inner_test()
+
+        self.assertEqual(register_settings.KEY_NAME, "name")
+        self.assertEqual(register_settings.LABEL_NAME, "pretty_name")
+
+    def test_invalid_setting_raises_attribute_error(self):
+        from django_register.settings import settings as register_settings
+
+        with self.assertRaises(AttributeError) as context:
+            _ = register_settings.INVALID_SETTING
+
+        self.assertIn("Invalid REGISTER_FIELD setting", str(context.exception))
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_label_name_behavior_unified(self):
+        @dataclass(unsafe_hash=True)
+        class Item:
+            name: str
+            pretty_name: str
+
+        class ItemChoices(RegisterChoices):
+            TEST = Item(name="test", pretty_name="Pretty Name")
+
+        choices_from_register_choices = ItemChoices.choices
+        self.assertEqual(dict(choices_from_register_choices), {"test": "Pretty Name"})
+
+        choices_from_register = ItemChoices.register.choices
+        self.assertEqual(dict(choices_from_register), {"test": "Pretty Name"})
+
+        class TestModel(models.Model):
+            item = RegisterField(choices=ItemChoices)
+
+            class Meta:
+                app_label = "tests"
+
+        field_choices = TestModel._meta.get_field("item").choices
+        self.assertEqual(dict(field_choices), {"test": "Pretty Name"})
+
+    @override_settings(
+        REGISTER_FIELD_KEY_NAME="name", REGISTER_FIELD_LABEL_NAME="pretty_name"
+    )
+    def test_mixed_settings_comprehensive(self):
+        @dataclass(unsafe_hash=True)
+        class Product:
+            name: str
+            pretty_name: str
+            price: float
+
+        class ProductChoices(RegisterChoices):
+            LAPTOP = Product(name="lpt", pretty_name="Laptop Computer", price=999.99)
+            PHONE = Product(name="phn", pretty_name="Smart Phone", price=699.99)
+
+        class Order(models.Model):
+            product = RegisterField(choices=ProductChoices)
+
+            class Meta:
+                app_label = "tests"
+
+        choices = ProductChoices.choices
+        self.assertEqual(
+            dict(choices), {"lpt": "Laptop Computer", "phn": "Smart Phone"}
+        )
+
+        register = ProductChoices.register
+        self.assertEqual(register.from_class(ProductChoices.LAPTOP), "lpt")
+        self.assertEqual(register.from_key("lpt"), ProductChoices.LAPTOP)
+
+        field_choices = Order._meta.get_field("product").choices
+        self.assertEqual(
+            dict(field_choices), {"lpt": "Laptop Computer", "phn": "Smart Phone"}
+        )
+
+        field = DRFRegisterField(
+            register=ProductChoices.register, keys=["name", "pretty_name", "price"]
+        )
+
+        representation = field.to_representation(ProductChoices.LAPTOP)
+        expected = {"name": "lpt", "pretty_name": "Laptop Computer", "price": 999.99}
+        self.assertEqual(representation, expected)

--- a/to_release.txt
+++ b/to_release.txt
@@ -1,2 +1,2 @@
-python3.11 setup.py sdist
+python setup.py sdist
 twine upload dist/*


### PR DESCRIPTION
Introduces a settings module allowing customization of key and label attribute names via REGISTER_FIELD_KEY_NAME and REGISTER_FIELD_LABEL_NAME. Refactors core, test, and serializer code to use these settings, renaming 'label' to 'key' and 'verbose_name' to 'label' by default. Updates models, migrations, and tests to reflect the new naming convention, and adds migration documentation for v1 to v2.